### PR TITLE
Update date

### DIFF
--- a/index.html
+++ b/index.html
@@ -392,7 +392,7 @@
             <div class="col-xxl-6 col-xl-6 col-lg-6 col-md-10 col-sm-12 my-auto">
               <div class="container p-5 mob-text">
                 <h3 class="fw-bold">THERE'S NEVER BEEN A BETTER TIME TO BUY!</h3>
-                <p>*This finance offer from Kubota New Zealand Limited is only available to eligible business applicants on loans with a term of up to 36 months. The 1.5% p.a. interest rate is fixed for the term of the loan and is only available with a minimum 10% deposit and applies to new Kubota KX & U Series products. Credit criteria, fees, terms and conditions apply. The finance offer is valid to 30/06/2024.</p>                
+                <p>*This finance offer from Kubota New Zealand Limited is only available to eligible business applicants on loans with a term of up to 36 months. The 1.5% p.a. interest rate is fixed for the term of the loan and is only available with a minimum 10% deposit and applies to new Kubota KX & U Series products. Credit criteria, fees, terms and conditions apply. The finance offer is valid to 31/10/2024.</p>                
               </div>
             </div>
           </div>


### PR DESCRIPTION
now - The finance offer is valid to 31/10/2024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
	- Extended the validity date of a finance offer from Kubota New Zealand Limited on specific loans to October 31, 2024.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->